### PR TITLE
Update ProjectFileParser.groovy

### DIFF
--- a/src/main/groovy/com/ullink/ProjectFileParser.groovy
+++ b/src/main/groovy/com/ullink/ProjectFileParser.groovy
@@ -197,7 +197,13 @@ class ProjectFileParser {
                     }
                 }
             } else {
-                importProjectFile(findImportFile(file.parentFile, str))
+                    try{
+    					importProjectFile(findImportFile(file.parentFile, str))
+					}
+					catch(Exception e){
+						String s = str.replace('Program Files','Program Files (x86)')
+						importProjectFile(findImportFile(file.parentFile, s))
+					}
             }
             return true
         }


### PR DESCRIPTION
On 64 bit systems, the default variable MSBuildExtensionsPath = MSBuildExtensionsPath64.
However, the default installation path of WinPhone sdk contains MSBuildExtensionsPath32.
So plugin search imports from autogenerated *.csproj file, which contain $(MSBuildExtensionsPath), in MSBuildExtensionsPath64, but it is contained in MSBuildExtensionsPath32. With this change plugin trying to find the imports in MSBuildExtensionsPath64. Then if the exception plugin trying to find the imports in MSBuildExtensionsPath32.
