### PR TITLE
Make MsBuild tasks unconditionally depend on AssemblyInfoVersionPatch…

### DIFF
--- a/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
+++ b/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
@@ -26,11 +26,7 @@ class AssemblyInfoVersionPatcher extends ConventionTask {
         project.afterEvaluate {
             if (!version) return;
             project.tasks.withType(Msbuild) { task ->
-                task.projects.each { proj ->
-                    if (proj.value.getItems('Compile').intersect(files)) {
-                        task.dependsOn this
-                    }
-                }
+                task.dependsOn this
             }
         }
     }


### PR DESCRIPTION
I'm still trying to get the plugin to complete the configuration phase without requiring mono, and found another case where mono gets invoked during the configuration phase: when AssemblyInfoVersionPatcher is enabled, it will check at configuration time which MSBuild projects include the files and then add a dependency.

This change makes all `MSbuild` tasks depend on `AssemblyInfoVersionPatcher` tasks. This should actually be fine, because it shouldn't trigger the msbuild unless one of the msbuild projects is actually changed by the assembly info patcher task. 
