### PR TITLE
Add a way to get the full path to any referenced DLL

### DIFF
--- a/src/main/groovy/com/ullink/ProjectFileParser.groovy
+++ b/src/main/groovy/com/ullink/ProjectFileParser.groovy
@@ -75,6 +75,16 @@ class ProjectFileParser {
         }
     }
 
+    File findReferencedDll(String  dllName) {
+        def dllPath = references.find {
+            it.Filename.startsWith(dllName)
+        }.HintPath
+        println dllPath
+        if(dllPath == null || "".equals(dllPath))
+            null
+        findProjectFile(dllPath)
+    }
+
     static String ospath(String path) {
         path.replaceAll("\\\\|/", "\\" + System.getProperty("file.separator"))
     }

--- a/src/test/groovy/com/ullink/MsbuildPluginTest.groovy
+++ b/src/test/groovy/com/ullink/MsbuildPluginTest.groovy
@@ -49,7 +49,7 @@ class MsbuildPluginTest {
             Target(Name:'Test')
             ItemGroup {
                 Reference (Include:"DevExpress.Charts.v10.2.Core, Version=10.2.5.0, Culture=neutral, PublicKeyToken=6935958ad4a06599, processorArchitecture=MSIL") {
-                    HintPath ("packages\\DevExpress.10.2.5.WinForms.10.2.5.3\\lib\net35\\DevExpress.Charts.v10.2.Core.dll")
+                    HintPath (["packages", "DevExpress.10.2.5.WinForms.10.2.5.3","lib","net35","DevExpress.Charts.v10.2.Core.dll"].join(File.separator))
                     Private: "True"
                 }
             }
@@ -64,10 +64,7 @@ class MsbuildPluginTest {
         p.msbuild {
             projectFile = file
         }
-        println file
-        println p.tasks.msbuild.mainProject.findReferencedDll("DevExpress.Charts").getCanonicalPath()
-        println file.getParentFile().getCanonicalPath() + File.separator + "packages\\DevExpress.10.2.5.WinForms.10.2.5.3\\lib\net35\\DevExpress.Charts.v10.2.Core.dll"
-        assertTrue((file.getParentFile().getCanonicalPath() + File.separator + "packages\\DevExpress.10.2.5.WinForms.10.2.5.3\\lib\net35\\DevExpress.Charts.v10.2.Core.dll").equals(p.tasks.msbuild.mainProject.findReferencedDll("DevExpress.Charts").getCanonicalPath()))
+        assertTrue((file.getParentFile().getCanonicalPath() + File.separator + ["packages", "DevExpress.10.2.5.WinForms.10.2.5.3","lib","net35","DevExpress.Charts.v10.2.Core.dll"].join(File.separator)).equals(p.tasks.msbuild.mainProject.findReferencedDll("DevExpress.Charts").getCanonicalPath()))
     }
 
     @Test

--- a/src/test/groovy/com/ullink/MsbuildPluginTest.groovy
+++ b/src/test/groovy/com/ullink/MsbuildPluginTest.groovy
@@ -40,6 +40,36 @@ class MsbuildPluginTest {
         }
         p.tasks.msbuild.execute()
     }
+
+    @Test
+    public void testGetReferenceLibPath() {
+        def writer = new StringWriter()
+        def xml = new MarkupBuilder(writer)
+        xml.Project(ToolsVersion:"4.0", DefaultTargets:"Test", xmlns:"http://schemas.microsoft.com/developer/msbuild/2003") {
+            Target(Name:'Test')
+            ItemGroup {
+                Reference (Include:"DevExpress.Charts.v10.2.Core, Version=10.2.5.0, Culture=neutral, PublicKeyToken=6935958ad4a06599, processorArchitecture=MSIL") {
+                    HintPath ("packages\\DevExpress.10.2.5.WinForms.10.2.5.3\\lib\net35\\DevExpress.Charts.v10.2.Core.dll")
+                    Private: "True"
+                }
+            }
+        }
+        File file = File.createTempFile("temp",".scrap");
+        file.with {
+            deleteOnExit()
+            write writer.toString()
+        }
+        Project p = ProjectBuilder.builder().build()
+        p.apply plugin: 'msbuild'
+        p.msbuild {
+            projectFile = file
+        }
+        println file
+        println p.tasks.msbuild.mainProject.findReferencedDll("DevExpress.Charts").getCanonicalPath()
+        println file.getParentFile().getCanonicalPath() + File.separator + "packages\\DevExpress.10.2.5.WinForms.10.2.5.3\\lib\net35\\DevExpress.Charts.v10.2.Core.dll"
+        assertTrue((file.getParentFile().getCanonicalPath() + File.separator + "packages\\DevExpress.10.2.5.WinForms.10.2.5.3\\lib\net35\\DevExpress.Charts.v10.2.Core.dll").equals(p.tasks.msbuild.mainProject.findReferencedDll("DevExpress.Charts").getCanonicalPath()))
+    }
+
     @Test
     public void execution_nonExistentProjectFile_throwsGradleException() {
         Project p = ProjectBuilder.builder().build()


### PR DESCRIPTION
This PR introduces a new method to get the full path to any DLL referenced inside the csproj file.
This may be usefull to use a DLL (without having to hardcode its full path) in tools such as sonar.
