### PR TITLE
Ignore MSBuild directories that don't have MSBuild.exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 3.7
 ### Fixed
 * Unzip binaries into temporaryDir of the task
+* Prevent using MSBuild paths that don't actually contain msbuild.exe
 
 # 3.6
 ### Added

--- a/src/main/groovy/com/ullink/MsbuildResolver.groovy
+++ b/src/main/groovy/com/ullink/MsbuildResolver.groovy
@@ -38,8 +38,11 @@ class MsbuildResolver implements IExecutableResolver {
         }
         msbuild.logger.info("Found the following MSBuild (using vswhere) installation folder: ${msbuildDir}")
         msbuildDir.eachDirMatch(~/(?i)(\d+(\.\d+)*|current)/) { dir ->
-            msbuild.msbuildDir = new File(dir, 'Bin')
-            return
+            def hasMsbuildExe = new File(dir, 'Bin\\msbuild.exe').exists()
+            msbuild.logger.debug("Found MSBuild directory: $dir; ${hasMsbuildExe ? 'OK' : 'Does not have msbuild.exe'}")
+            if (hasMsbuildExe) {
+                msbuild.msbuildDir = new File(dir, 'Bin')
+            }
         }
     }
 
@@ -47,7 +50,7 @@ class MsbuildResolver implements IExecutableResolver {
         List<String> availableVersions =
             getMsBuildVersionsFromRegistry(MSBUILD_WOW6432_PREFIX) +
             getMsBuildVersionsFromRegistry(MSBUILD_PREFIX)
-        msbuild.logger.debug("Found the following MSBuild (in the registry) versions: ${availableVersions}")
+        msbuild.logger.info("Found the following MSBuild (in the registry) versions: ${availableVersions}")
 
         List<String> versionsToCheck
         if (msbuild.version != null) {


### PR DESCRIPTION
In the latest version(s), we have for example "15.0", that doesn't
contain anything besides some roslyn-related dlls:

C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\15.0\Bin\Roslyn