### PR TITLE
Always use latest msbuild installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # gradle-msbuild-plugin changelog
 
-#3.8
+# 3.8
 ### Fixed
-* MSBuildCustomLocator retrieves the latest msbuildtools version
+* MSBuildCustomLocator register the greatest/latest installed Visual Studio version (instead of the first it finds).
 
 # 3.7
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # gradle-msbuild-plugin changelog
 
+#3.8
+### Fixed
+* MSBuildCustomLocator retrieves the latest msbuildtools version
+
 # 3.7
 ### Fixed
 * Unzip binaries into temporaryDir of the task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 3.8
 ### Fixed
-* MSBuildCustomLocator register the greatest/latest installed Visual Studio version (instead of the first it finds).
+* The greatest/latest installed Visual Studio version is used to parse the project & solutions (instead of the first it finds).
 
 # 3.7
 ### Fixed

--- a/src/main/dotnet/ProjectFileParser/MSBuildCustomLocator.cs
+++ b/src/main/dotnet/ProjectFileParser/MSBuildCustomLocator.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Build.Locator;
 using System;
+using System.Linq;
 
 namespace ProjectFileParser
 {
@@ -9,7 +10,9 @@ namespace ProjectFileParser
         {
             try
             {
-                MSBuildLocator.RegisterDefaults();
+                var latestVsVersion = MSBuildLocator.QueryVisualStudioInstances().OrderBy(vsInstance => vsInstance.Version).Last();
+                MSBuildLocator.RegisterInstance(latestVsVersion);
+                Console.Error.WriteLine($"Registered latest VS Instance: {latestVsVersion.Name} - {latestVsVersion.Version} - {latestVsVersion.MSBuildPath} - {latestVsVersion.DiscoveryType} - {latestVsVersion.VisualStudioRootPath}");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The MSBuildCustomLocator was sometimes identifying MS buildtools 2017, even though 2019 was available as well on the machine, thus causing some builds requiring components from msbuildtools 2019 to fail.