### PR TITLE
Cleanup temp folders on exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # gradle-msbuild-plugin changelog
 
+# 3.16
+### Fixed
+* Cleanup temporary folders an exit
+
 # 3.15
 ### Fixed
 * Gradle 7 support on AssemblyInfoVersionPatcher

--- a/src/main/groovy/com/ullink/Msbuild.groovy
+++ b/src/main/groovy/com/ullink/Msbuild.groovy
@@ -118,6 +118,7 @@ class Msbuild extends ConventionTask {
             throw new GradleException("Project/Solution file $file does not exist")
         }
         File tempDir = Files.createTempDirectory(temporaryDir.toPath(), 'ProjectFileParser').toFile()
+        tempDir.deleteOnExit()
 
         this.class.getResourceAsStream('/META-INF/ProjectFileParser.zip').withCloseable  {
             ZipInputStream zis = new ZipInputStream(it)

--- a/src/main/groovy/com/ullink/MsbuildResolver.groovy
+++ b/src/main/groovy/com/ullink/MsbuildResolver.groovy
@@ -14,6 +14,7 @@ class MsbuildResolver implements IExecutableResolver {
     // Find msbuild >= 15.0 by vswhere
     static def findMsbuildByVsWhere(Msbuild msbuild) {
         File tempDir = Files.createTempDirectory(msbuild.temporaryDir.toPath(), 'vswhere').toFile()
+        tempDir.deleteOnExit()
 
         def vswhereFile = new File(tempDir, 'vwshere.exe')
         Resources.asByteSource(MsbuildResolver.getResource("/vswhere.exe")).copyTo(com.google.common.io.Files.asByteSink(vswhereFile))


### PR DESCRIPTION
These temp folders are created on each run an over time tend to take out a lot of space